### PR TITLE
Fix length issue for good

### DIFF
--- a/src/fulfiller/Fulfiller.sol
+++ b/src/fulfiller/Fulfiller.sol
@@ -202,6 +202,17 @@ contract Fulfiller is IFulfiller, IFulfillerWithCallback, Ownable2Step, Pausable
 
         // Execute a swap with each iteration.
         while (msg.data.length > ptr) {
+            // Break the loop if only padding is left.
+            unchecked {
+                if (msg.data.length - ptr < 32) {
+                    bool paddingRemainingOnly;
+                    assembly {
+                        paddingRemainingOnly := iszero(calldataload(ptr))
+                    }
+                    if (paddingRemainingOnly) break;
+                }
+            }
+
             // Decode first swap instructions from ptr, ensuring executor is not disabled.
             (ptr, executorId, swap) = _decodeSwap(ptr);
 


### PR DESCRIPTION
> r0bert-ethack noted
>
> Error seems to be present in this line:
>
> ```solidity
> while (msg.data.length > ptr)
> ```
>
> `bytes calldata context` will always be padded to a 32 bytes multiple. This means that the loop will be re-entered incorrectly a second time. For example, based in the following `extraData`: `01EE00000000000000000000003B9ACA00000000000000000000000000000001000000000000000000000000000000000000021B01` (53 bytes)
>
>     * The pointer is set initially to 644.
>
>     * msg.data.length is 708.
>
>     * The pointer after the first iteration of the loop is set to 697.
>
>     * 697 - 53 = 644.
>
>
> Although, as 697 < `msg.data.length` the loop will be re-entered a second time reading wrong/non existent data @fulminmaxi